### PR TITLE
Introduce a ert based small test harnetss and two example test cases

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+EMACS=${EMACA:=emacs}
+PRELAOD=citre.el
+
+d=$(pwd)
+prealod_options=
+
+error()
+{
+    echo "$@" 1>&2
+    exit 1
+}
+
+for p in $PRELAOD; do
+    [ ! -e  $p ] && error "cannot find $p"
+    # Convert to complete file path
+    if [ ${p:0:1} != '/' ]; then
+       p=${d}/$p
+    fi
+    prealod_options="${prealod_options}-l $p "
+done
+
+for t in tests/*/test.el; do
+    d=$(dirname $t)
+    (cd $d
+     if ! $EMACS -batch -l ert $prealod_options -l ../common.el -l ./test.el \
+	  -f ert-run-tests-batch-and-exit; then
+	 error "testing is failed in $d"
+     fi
+     )
+done
+
+echo "OK"
+exit 0

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-EMACS=${EMACA:=emacs}
-PRELAOD=citre.el
+EMACS=${EMACS:=emacs}
+PRELOAD=citre.el
 
 d=$(pwd)
-prealod_options=
+preload_options=
 
 error()
 {
@@ -12,19 +12,19 @@ error()
     exit 1
 }
 
-for p in $PRELAOD; do
+for p in $PRELOAD; do
     [ ! -e  $p ] && error "cannot find $p"
     # Convert to complete file path
     if [ ${p:0:1} != '/' ]; then
        p=${d}/$p
     fi
-    prealod_options="${prealod_options}-l $p "
+    preload_options="${preload_options}-l $p "
 done
 
 for t in tests/*/test.el; do
     d=$(dirname $t)
     (cd $d
-     if ! $EMACS -batch -l ert $prealod_options -l ../common.el -l ./test.el \
+     if ! $EMACS -batch -l ert $preload_options -l ../common.el -l ./test.el \
 	  -f ert-run-tests-batch-and-exit; then
 	 error "testing is failed in $d"
      fi

--- a/test.sh
+++ b/test.sh
@@ -26,7 +26,7 @@ for t in tests/*/test.el; do
     (cd $d
      if ! $EMACS -batch -l ert $preload_options -l ../common.el -l ./test.el \
 	  -f ert-run-tests-batch-and-exit; then
-	 error "testing is failed in $d"
+	 error "test in $d failed"
      fi
      exit 0
      ) || exit 1

--- a/test.sh
+++ b/test.sh
@@ -28,7 +28,8 @@ for t in tests/*/test.el; do
 	  -f ert-run-tests-batch-and-exit; then
 	 error "testing is failed in $d"
      fi
-     )
+     exit 0
+     ) || exit 1
 done
 
 echo "OK"

--- a/tests/common.el
+++ b/tests/common.el
@@ -1,0 +1,11 @@
+;;
+;; common codes for testing should be put here.
+;;
+(defconst default-tags "target.tags")
+(defconst default-test "test.el")
+(defmacro with-me (&rest body)
+  `(with-current-buffer (find-file-noselect default-test)
+     ,@body))
+
+(defun expand-test-file (f)
+  (expand-file-name (concat default-directory f)))

--- a/tests/common.el
+++ b/tests/common.el
@@ -22,4 +22,4 @@ FILE is a relative path against the test case directory.
 This is for use in the batch mode.  You should start Emacs with
 the working directory being a test case directory to ensure this
 work correctly."
-  (expand-file-name (concat default-directory f)))
+  (expand-file-name (concat default-directory file)))

--- a/tests/common.el
+++ b/tests/common.el
@@ -1,11 +1,25 @@
 ;;
 ;; common codes for testing should be put here.
 ;;
-(defconst default-tags "target.tags")
-(defconst default-test "test.el")
+(defconst default-tags "target.tags"
+  "Default tags file under each test case directory.")
+
+(defconst default-test "test.el"
+  "Default test to run under each test case directory.")
+
 (defmacro with-me (&rest body)
+  "Eval BODY in the buffer of `default-test' file.
+This is for use in the batch mode.  You should start Emacs with
+the working directory being a test case directory to ensure this
+work correctly."
   `(with-current-buffer (find-file-noselect default-test)
      ,@body))
 
-(defun expand-test-file (f)
+(defun expand-test-file (file)
+  "Get the absolute path of FILE.
+FILE is a relative path against the test case directory.
+
+This is for use in the batch mode.  You should start Emacs with
+the working directory being a test case directory to ensure this
+work correctly."
   (expand-file-name (concat default-directory f)))

--- a/tests/mini/.ctags.d/0.ctags
+++ b/tests/mini/.ctags.d/0.ctags
@@ -1,0 +1,3 @@
+--fields=Kz{line}{signature}
+-L .ctags.d/src.list
+-o target.tags

--- a/tests/mini/.ctags.d/src.list
+++ b/tests/mini/.ctags.d/src.list
@@ -1,0 +1,3 @@
+src/input-area.cpp
+src/input-volume.cpp
+src/input.h

--- a/tests/mini/src/input-area.cpp
+++ b/tests/mini/src/input-area.cpp
@@ -1,0 +1,11 @@
+#include "input.h"
+
+float area   (ipoint2d &p)
+{
+  return (float)(p.x * p.y);
+}
+
+float area   (fpoint2d &p)
+{
+  return p.x * p.y;
+}

--- a/tests/mini/src/input-volume.cpp
+++ b/tests/mini/src/input-volume.cpp
@@ -1,0 +1,11 @@
+#include "input.h"
+
+float volume (ipoint3d *p)
+{
+  return (float)(p->x * p->y * p->z);
+}
+
+float volume (fpoint3d *p)
+{
+  return area (p->parent) * p->z;
+}

--- a/tests/mini/src/input.h
+++ b/tests/mini/src/input.h
@@ -1,0 +1,26 @@
+#ifndef INPUT_DATA_H
+#define INPUT_DATA_H
+
+struct ipoint2d {
+  int x, y;
+};
+
+struct ipoint3d {
+  int x, y, z;
+};
+
+struct fpoint2d {
+  float x, y;
+};
+
+struct fpoint3d {
+  fpoint2d parent;
+  float z;
+};
+
+float area   (ipoint2d &p);
+float area   (fpoint2d &p);
+float volume (ipoint3d *p);
+float volume (fpoint3d *p);
+
+#endif 

--- a/tests/mini/src/input.h
+++ b/tests/mini/src/input.h
@@ -23,4 +23,4 @@ float area   (fpoint2d &p);
 float volume (ipoint3d *p);
 float volume (fpoint3d *p);
 
-#endif 
+#endif

--- a/tests/mini/target.tags
+++ b/tests/mini/target.tags
@@ -1,0 +1,27 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/45ff6b8a/
+INPUT_DATA_H	src/input.h	/^#define INPUT_DATA_H$/;"	kind:macro	line:2
+area	src/input-area.cpp	/^float area   (fpoint2d &p)$/;"	kind:function	line:8	signature:(fpoint2d & p)
+area	src/input-area.cpp	/^float area   (ipoint2d &p)$/;"	kind:function	line:3	signature:(ipoint2d & p)
+fpoint2d	src/input.h	/^struct fpoint2d {$/;"	kind:struct	line:12
+fpoint3d	src/input.h	/^struct fpoint3d {$/;"	kind:struct	line:16
+ipoint2d	src/input.h	/^struct ipoint2d {$/;"	kind:struct	line:4
+ipoint3d	src/input.h	/^struct ipoint3d {$/;"	kind:struct	line:8
+parent	src/input.h	/^  fpoint2d parent;$/;"	kind:member	line:17
+volume	src/input-volume.cpp	/^float volume (fpoint3d *p)$/;"	kind:function	line:8	signature:(fpoint3d * p)
+volume	src/input-volume.cpp	/^float volume (ipoint3d *p)$/;"	kind:function	line:3	signature:(ipoint3d * p)
+x	src/input.h	/^  float x, y;$/;"	kind:member	line:13
+x	src/input.h	/^  int x, y, z;$/;"	kind:member	line:9
+x	src/input.h	/^  int x, y;$/;"	kind:member	line:5
+y	src/input.h	/^  float x, y;$/;"	kind:member	line:13
+y	src/input.h	/^  int x, y, z;$/;"	kind:member	line:9
+y	src/input.h	/^  int x, y;$/;"	kind:member	line:5
+z	src/input.h	/^  float z;$/;"	kind:member	line:18
+z	src/input.h	/^  int x, y, z;$/;"	kind:member	line:9

--- a/tests/mini/test.el
+++ b/tests/mini/test.el
@@ -1,14 +1,14 @@
 (ert-deftest test--get-lines ()
-  "Testing citre--get-lines"
+  "Testing `citre--get-lines'."
   (should (equal
-	   (with-me 
+	   (with-me
 	    (citre-mode 1)
 	    (citre--get-lines "z" 'exact default-tags default-directory))
 	   '("z	src/input.h	/^  float z;$/;\"	kind:member	line:18"
 	     "z	src/input.h	/^  int x, y, z;$/;\"	kind:member	line:9"))))
 
 (ert-deftest test-get-records ()
-  "Testing citre--get-records"
+  "Testing `citre--get-records'."
   (should (equal
 	   (with-me
 	    (setq citre-tags-files (cons default-tags citre-tags-files))

--- a/tests/mini/test.el
+++ b/tests/mini/test.el
@@ -1,0 +1,18 @@
+(ert-deftest test--get-lines ()
+  "Testing citre--get-lines"
+  (should (equal
+	   (with-me 
+	    (citre-mode 1)
+	    (citre--get-lines "z" 'exact default-tags default-directory))
+	   '("z	src/input.h	/^  float z;$/;\"	kind:member	line:18"
+	     "z	src/input.h	/^  int x, y, z;$/;\"	kind:member	line:9"))))
+
+(ert-deftest test-get-records ()
+  "Testing citre--get-records"
+  (should (equal
+	   (with-me
+	    (setq citre-tags-files (cons default-tags citre-tags-files))
+	    (citre-mode 1)
+	    (citre-get-records "z" 'exact default-directory))
+	   `(("z" "member" nil ,(expand-test-file "src/input.h") 18)
+	     ("z" "member" nil ,(expand-test-file "src/input.h") 9)))))

--- a/tests/mini/test.el
+++ b/tests/mini/test.el
@@ -1,18 +1,13 @@
 (ert-deftest test--get-lines ()
   "Testing `citre--get-lines'."
   (should (equal
-	   (with-me
-	    (citre-mode 1)
-	    (citre--get-lines "z" 'exact default-tags default-directory))
-	   '("z	src/input.h	/^  float z;$/;\"	kind:member	line:18"
-	     "z	src/input.h	/^  int x, y, z;$/;\"	kind:member	line:9"))))
+           (citre--get-lines "z" 'exact default-tags)
+           '("z	src/input.h	/^  float z;$/;\"	kind:member	line:18"
+             "z	src/input.h	/^  int x, y, z;$/;\"	kind:member	line:9"))))
 
 (ert-deftest test-get-records ()
   "Testing `citre--get-records'."
   (should (equal
-	   (with-me
-	    (setq citre-tags-files (cons default-tags citre-tags-files))
-	    (citre-mode 1)
-	    (citre-get-records "z" 'exact default-directory))
-	   `(("z" "member" nil ,(expand-test-file "src/input.h") 18)
-	     ("z" "member" nil ,(expand-test-file "src/input.h") 9)))))
+           (citre-get-records "z" 'exact default-tags default-directory)
+           `(("z" "member" nil ,(expand-test-file "src/input.h") 18)
+             ("z" "member" nil ,(expand-test-file "src/input.h") 9)))))


### PR DESCRIPTION
To run a test case:
```
$ cd citre
$ bash test.sh
```

e.g.:
```
[yamato@slave]~/var/citre% bash test.sh
bash test.sh
Loading /usr/share/emacs/site-lisp/site-start.d/anthy-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/autoconf-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/clang-format.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/cmake-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/ddskk-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/desktop-entry-mode-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/gforth-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/git-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/lookup-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/mercurial-site-start.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/mew-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/mozc-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/systemtap-init.el (source)...
Loading /usr/share/emacs/site-lisp/site-start.d/w3m-init.el (source)...
Running 2 tests (2020-04-22 07:46:10+0900)
   passed  1/2  test--get-lines
   passed  2/2  test-get-records

Ran 2 tests, 2 results as expected (2020-04-22 07:46:10+0900)

OK
```  
   
target.tags can be regenerated with

```
	    (cd tests/mini; u-ctags)
```


TODO: readtags must be parametrized.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>