### PR TITLE
Optimize core performance

### DIFF
--- a/citre-core.el
+++ b/citre-core.el
@@ -469,27 +469,21 @@ names, cdrs are the values."
     (0 `((name . ,(citre-core--read-field-value field))))
     (1 `((input . ,(citre-core--read-field-value field))))
     (2 `((pattern . ,field)))
-    (3 (let* ((parts (citre-core--split-at-1st-colon field))
-              (field-name (car parts))
-              (field-name (pcase field-name
-                            ('nil 'kind)
-                            (_ (intern field-name))))
-              (field-value (citre-core--read-field-value (cdr parts))))
-         `((,field-name . ,field-value))))
-    (_
-     (let* ((parts (citre-core--split-at-1st-colon field))
-            (field-name (car parts))
-            (field-value (citre-core--read-field-value (cdr parts))))
-       (pcase field-name
-         ("scope"
-          (let ((value (citre-core--split-at-1st-colon field-value)))
-            `((scope-kind . ,(car value))
-              (scope-name . ,(cdr value)))))
-         ((or "class" "struct")
-          `((scope-kind . ,field-name)
-            (scope-name . ,field-value)))
-         (_
-          `((,(intern field-name) . ,field-value))))))))
+    (_ (let* ((parts (citre-core--split-at-1st-colon field))
+              (name (car parts))
+              (name (or (when name (intern name))
+                        'kind))
+              (value (cdr parts)))
+         (pcase name
+           ('scope
+            (let ((value (citre-core--split-at-1st-colon value)))
+              `((scope-kind . ,(car value))
+                (scope-name . ,(citre-core--read-field-value (cdr value))))))
+           ((or 'class 'struct)
+            `((scope-kind . ,(symbol-name name))
+              (scope-name . ,(citre-core--read-field-value value))))
+           (_
+            `((,name . ,(citre-core--read-field-value value)))))))))
 
 ;;;;; Extension fields
 

--- a/citre-core.el
+++ b/citre-core.el
@@ -171,6 +171,17 @@ backslash is \"\\\\\"."
       (setq start (+ idx 2)))
     (nreverse result)))
 
+;; TODO: Do we need to support Windows style path?
+(defun citre-core--file-name-extension (file)
+  "Return the extension of FILE.
+If it doesn't have an extension, return the file name without
+directory.
+
+This is faster than `file-name-extension'."
+  (or (string-match "\\.\\([^./]+\\)$" file)
+      (string-match "/\\([^/]+\\)$" file))
+  (match-string 1 file))
+
 ;;;; Internals: Additional information handling
 
 (defvar citre-core--tags-file-info-method-alist
@@ -858,8 +869,7 @@ It tries these in turn:
 - Return nil."
   (or (gethash 'language record)
       (when-let ((input (gethash 'input record))
-                 (extension (or (file-name-extension input)
-                                (file-name-nondirectory input))))
+                 (extension (citre-core--file-name-extension input)))
         (or (gethash (downcase extension) citre-core--lang-extension-table)
             extension))))
 

--- a/citre-core.el
+++ b/citre-core.el
@@ -913,31 +913,6 @@ non-nil, also keep lines where FIELD is missing."
       (setq filter `(or (not ,field) ,filter)))
     filter))
 
-(defun citre-core-filter-match-input (tagsfile input)
-  "Return a filter expression that matches the input field by INPUT.
-INPUT can be canonical or relative, and it will be converted to
-canonical (relative) path if the tags file TAGSFILE uses
-canonical (relative) path.  TAGSFILE is a canonical path."
-  (let* ((pathinfo (citre-core--tags-file-info
-                    (citre-core--get-tags-file-info tagsfile 'path)
-                    'path 'value))
-         (tags-file-input-relative-p (car pathinfo))
-         (arg-input-relative-p (not (file-name-absolute-p input)))
-         (cwd (cdr pathinfo))
-         (no-cwd-error "Can't get absolute path.  You can:\n\
-1. Regenerate the tags file with \"TAG_PROC_CWD\" pseudo tag enabled, or\n\
-2. Regenerate the tags file using absolute paths in the command"))
-    (cond
-     ((and tags-file-input-relative-p (not arg-input-relative-p))
-      (unless cwd
-        (error no-cwd-error))
-      (setq input (substring input (length cwd))))
-     ((and (not tags-file-input-relative-p) arg-input-relative-p)
-      (unless cwd
-        (error no-cwd-error))
-      (setq input (concat cwd input))))
-    `(eq? $input ,input)))
-
 ;; TODO: Should we convert between single-letter and full-length kinds here?
 ;; The implementation would be messy since it also involves the language field,
 ;; and we need to match the file extension if the language field is missing.


### PR DESCRIPTION
I tried hard to make it faster to getting records. Various little optimizations, and a non-little one (using a stateful lexer for parsing tag lines), are applied. Here's a benchmark on my machine:

Code:

``` elisp
(benchmark-run-compiled 10
  (citre-core-get-records "/home/kino/linux-5.4.17/tags" "li" 'prefix nil
                          :require '(name kind)
                          :optional '(typeref)))
```

Result:

|                           | Execution time (s) | Execution time w/o GC (s) | GC time (s) |
|---------------------------|--------------------|---------------------------|-------------|
| Before optimization       | 4.7                | 4.0                       | 0.7         |
| Misc optimization applied | 3.9                | 3.4                       | 0.5         |
| Lexer used                | 3.2                | 2.8                       | 0.4         |

I feel this is the best I can do with the core.

During this work I learned that simple regexp (i.e., without `^`, `$`, `\|`, groups and stuffs) is faster, so the code of jumping over the pattern field may be further optimized. I tried searching for tabs and look back from it to know if it's the end of pattern. No complex regexp involved but we have to do some arithmetic. There is some, but little, performance gain, so I deprecated it.

Ideas of optimize other layers:

- Wrap time-consuming parts in a `let` block which sets `gc-cons-threshold` to a larger value, which should be a user option.

For `company` users (they need to call `completion-at-point-functions` frequently, basically for every char they types):

- Use `while-no-input` to stop fetching results when the user types. I've tried it, it works but still feels a bit laggy.
- Cache the results, so when the user continue typing and there's already some candidates, we could filter from them.

`company` is a popular package and comes with many Emacs starter-kits and user configs, so we have to make its users happy.